### PR TITLE
docs: fix simple typo, recieved -> received

### DIFF
--- a/get_pulse.py
+++ b/get_pulse.py
@@ -58,7 +58,7 @@ class getPulseApp(object):
                 break
         self.w, self.h = 0, 0
         self.pressed = 0
-        # Containerized analysis of recieved image frames (an openMDAO assembly)
+        # Containerized analysis of received image frames (an openMDAO assembly)
         # is defined next.
 
         # This assembly is designed to handle all image & signal analysis,


### PR DESCRIPTION
There is a small typo in get_pulse.py.

Should read `received` rather than `recieved`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md